### PR TITLE
Handler for invalid job types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 tests/azure_jobs
 tests/AZURE_CACHE.txt
 tests/list_jobs.sh
+
+# VS Code
+.vscode/

--- a/src/lambda_services/job_service/job_service.py
+++ b/src/lambda_services/job_service/job_service.py
@@ -126,9 +126,8 @@ def interpret_job_submission(event: dict, context=None):
     jobinfo_object_name: str = event["Records"][0]["s3"]["object"]["key"]
     bucket_name: str = event["Records"][0]["s3"]["bucket"]["name"]
     job_id = jobinfo_object_name.split("/")[0]
-    job_type = jobinfo_object_name.split("-")[0].split("/")[
-        1
-    ]  # Assumes 'pdb2pqr-job.json', or similar format
+    # Assumes 'pdb2pqr-job.json', or similar format
+    job_type = jobinfo_object_name.split("-")[0].split("/")[1]  
 
     # If PDB2PQR:
     #   - Obtain job configuration from config file

--- a/src/lambda_services/job_service/job_service.py
+++ b/src/lambda_services/job_service/job_service.py
@@ -11,6 +11,10 @@ FARGATE_SERVICE = os.getenv('FARGATE_SERVICE')
 # Could use SQS URL below instead of a queue name; whichever is easier
 SQS_QUEUE_NAME = os.getenv('JOB_QUEUE_NAME')
 
+# Initialize logger
+LOGGER = logging.getLogger()
+LOGGER.setLevel(os.getenv('LOG_LEVEL', logging.INFO))
+
 
 def get_job_info(bucket_name: str, info_object_name: str) -> dict:
     """Retrieve job configuraiton JSON object from S3, and return as dict.
@@ -147,8 +151,8 @@ def interpret_job_submission(event: dict, context=None):
     else:
         status = "invalid"
         message = "Invalid job type. No job executed"
-        logging.error("Invalid job type - Job ID: %s, Job Type: %s",
-                      job_id, job_type)
+        LOGGER.error("Invalid job type - Job ID: %s, Job Type: %s",
+                     job_id, job_type)
 
     # Create and upload status file to S3
     status_filename = f'{job_type}-status.json'

--- a/tests/test_job_service.py
+++ b/tests/test_job_service.py
@@ -1,0 +1,47 @@
+"""Tests for interpreting and handling job configuration submissions."""
+from src.lambda_services.job_service.job_service import build_status_dict
+
+
+def test_build_status_dict_valid_job():
+    """Test funciton for initial status creation for valid jobtypes"""
+
+    # Valid job
+    job_id = "sampleId"
+    job_type = "apbs"
+    input_files = ["sampleId.in", "1fas.pqr"]
+    output_files = []
+    job_status = "pending"
+    status_dict: dict = build_status_dict(job_id, job_type, job_status,
+                                          input_files, output_files,
+                                          message=None)
+    assert "jobid" in status_dict
+    assert "jobtype" in status_dict
+    assert job_type in status_dict
+    assert "status" in status_dict[job_type]
+    assert status_dict[job_type]["status"] == "pending"
+    assert status_dict[job_type]["endTime"] is None
+    assert isinstance(status_dict[job_type]["startTime"], float)
+    assert isinstance(status_dict[job_type]["inputFiles"], list)
+    assert isinstance(status_dict[job_type]["outputFiles"], list)
+
+
+def test_build_status_dict_invalid_job():
+    """Test funciton for initial status creation for invalid jobtypes"""
+
+    # Invalid job
+    job_id = "sampleId"
+    job_type = "nonsenseJobType"
+    input_files = None
+    output_files = None
+    job_status = "invalid"
+    invalid_message = "Invalid job type"
+    status_dict: dict = build_status_dict(job_id, job_type, job_status,
+                                          input_files, output_files,
+                                          message=invalid_message)
+    assert "status" in status_dict[job_type]
+    assert "message" in status_dict[job_type]
+    assert status_dict[job_type]["status"] == "invalid"
+    assert status_dict[job_type]["startTime"] is None
+    assert status_dict[job_type]["inputFiles"] is None
+    assert status_dict[job_type]["outputFiles"] is None
+    # assert status_dict[job_type]["subtasks"] == None


### PR DESCRIPTION
**Resolves #24** 

If job jobtype extracted is not among valid types ("apbs", "pdbp2qr"), then no job is submitted to queue and an associated status is uploaded.

Included in PR:
* Invalid job type handler
* Tests for invalid job

Example:
```
{
    "jobid": "sampleId",
    "jobtype": "invalidType",
    "invalidType": {
        "status": "invalid",
        "startTime": null,
        "endTime": null,
        "subtasks": null,
        "inputFiles": null,
        "outputFiles": null,
        "message": "Invalid job type. No job executed"
    }
}
```