### PR TITLE
Added 'context' parameter for Lambda handlers

### DIFF
--- a/lambda_services/api_service/api_service.py
+++ b/lambda_services/api_service/api_service.py
@@ -33,7 +33,7 @@ def create_s3_url(bucket_name: str, file_name: str, prefix_name: str) -> str:
     return url
 
 
-def generate_id_and_tokens(event: dict) -> dict:
+def generate_id_and_tokens(event: dict, context) -> dict:
     """Generate an unique job id and S3 auth tokens"""
 
     # Assign object variables from Lambda event

--- a/lambda_services/job_service/job_service.py
+++ b/lambda_services/job_service/job_service.py
@@ -115,10 +115,12 @@ def upload_status_file(object_filename: str, initial_status_dict: dict):
     )
 
 
-def interpret_job_submission(event: dict):
+def interpret_job_submission(event: dict, context):
     """Interpret contents of job configuration, triggered from S3 event.
 
     :param event dict: Amazon S3 event, containing info to retrieve contents
+    :param context: context object for AWS Lambda handler, containing info
+                    about the invocation, function, and execution environment
     """
 
     # Get basic job information from S3 event


### PR DESCRIPTION
Resolves #76, where the AWS Lambda handler failed to pass in the arguments required