### PR TITLE
Set log level in separate logger object

### DIFF
--- a/lambda_services/api_service/api_service.py
+++ b/lambda_services/api_service/api_service.py
@@ -17,14 +17,18 @@ def apbs_logger():
     Returns:
         Logger: An all encompassing logger.
     """
-    _apbs_logger = getLogger()
-    for handler in _apbs_logger.handlers:
+    # Override Lambda's log format
+    root_logger = getLogger()
+    for handler in root_logger.handlers:
         handler.setFormatter(
             Formatter(
                 "[%(aws_request_id)s] [%(levelname)s] "
                 "[%(filename)s:%(lineno)s:%(funcName)s()] %(message)s"
             )
         )
+
+    # Set log level for our context
+    _apbs_logger = getLogger(__name__)
     _apbs_logger.setLevel(getenv("LOG_LEVEL", getLevelName(INFO)))
     return _apbs_logger
 

--- a/lambda_services/job_service/job_service.py
+++ b/lambda_services/job_service/job_service.py
@@ -40,7 +40,7 @@ def get_job_info(
     except (ClientError) as err:
         _LOGGER.exception(
             "%s Unable to get object for Bucket, %s, and Key, %s: %s",
-            f"{bucket_name}/{info_object_name}",
+            job_tag,
             bucket_name,
             info_object_name,
             err,
@@ -198,7 +198,7 @@ def interpret_job_submission(event: dict, context):
         #   - Log and (maybe) raise exception
         status = "invalid"
         message = "Invalid job type. No job executed"
-        _LOGGER.error("%s Invalid job type - Job Type: %s", job_id, job_type)
+        _LOGGER.error("%s Invalid job type - Job Type: %s", job_tag, job_type)
 
     if job_type in ("apbs", "pdb2pqr"):
         input_files = job_runner.input_files

--- a/lambda_services/job_service/launcher/apbs_runner.py
+++ b/lambda_services/job_service/launcher/apbs_runner.py
@@ -155,7 +155,9 @@ class Runner(JobSetup):
 
             except Exception as err:
                 _LOGGER.exception(
-                    "%s Failed to remove water molecules: %s", self.job_id, err
+                    "%s Failed to remove water molecules: %s",
+                    self.job_tag,
+                    err,
                 )
                 raise
 
@@ -270,7 +272,10 @@ class Runner(JobSetup):
         if apbs_options["writeCheck"] > 4:
             # TODO: 2021/03/02, Elvis - validation error;
             #       please raise exception here
-            _LOGGER.error("Please select a maximum of four write statements.")
+            _LOGGER.error(
+                "%s Please select a maximum of four write statements.",
+                self.job_tag,
+            )
 
         # READ section variables
         apbs_options["readType"] = "mol"

--- a/lambda_services/job_service/launcher/pdb2pqr_runner.py
+++ b/lambda_services/job_service/launcher/pdb2pqr_runner.py
@@ -107,7 +107,7 @@ class Runner(JobSetup):
                 cli_arg = f"--{pair[0]}={str(pair[1])}"
             result = f"{result} {cli_arg}"
 
-            # Add PDB and PQR file names to command line string
+        # Add PDB and PQR file names to command line string
         result = (
             f"{result} {self.cli_params['pdb_name']} "
             f"{self.cli_params['pqr_name']}"
@@ -150,9 +150,9 @@ class Runner(JobSetup):
         if "--summary" in result:
             result = result.replace("--summary", "")
 
-        _LOGGER.debug("%s Result: %s", job_id, result)
+        _LOGGER.debug("%s Generated CLI args: %s", self.job_tag, result)
         _LOGGER.debug(
-            "%s PDB Filename: %s", job_id, self.weboptions.pdbfilename
+            "%s PDB Filename: %s", self.job_tag, self.weboptions.pdbfilename
         )
 
         return result

--- a/lambda_services/job_service/launcher/utils.py
+++ b/lambda_services/job_service/launcher/utils.py
@@ -129,8 +129,6 @@ def s3_object_exists(bucket_name: str, object_name: str) -> bool:
         if err.response["Error"]["Message"] == "NoSuchKey":
             return False
         elif err.response["Error"]["Message"] == "Forbidden":
-            # objectname_split: list = object_name.split("/")
-            # job_tag: str = f"{objectname_split[-3]}/{objectname_split[-2]}"
             job_tag: str = _extract_job_tag_from_objectname(object_name)
             _LOGGER.warning(
                 "%s Received '%s' (%d) message on object HEAD: %s",

--- a/lambda_services/job_service/launcher/utils.py
+++ b/lambda_services/job_service/launcher/utils.py
@@ -1,7 +1,7 @@
 """A collection of utility functions."""
 
 from io import StringIO
-from logging import getLevelName, getLogger, Formatter, INFO
+from logging import getLevelName, getLogger, Formatter, INFO, root
 from re import split
 from os import getenv
 from boto3 import client
@@ -14,14 +14,18 @@ def apbs_logger():
     Returns:
         Logger: An all encompassing logger.
     """
-    _apbs_logger = getLogger()
-    for handler in _apbs_logger.handlers:
+    # Override Lambda's log format
+    root_logger = getLogger()
+    for handler in root_logger.handlers:
         handler.setFormatter(
             Formatter(
                 "[%(aws_request_id)s] [%(levelname)s] "
                 "[%(filename)s:%(lineno)s:%(funcName)s()] %(message)s"
             )
         )
+
+    # Set log level for our context
+    _apbs_logger = getLogger(__name__)
     _apbs_logger.setLevel(getenv("LOG_LEVEL", getLevelName(INFO)))
     return _apbs_logger
 

--- a/lambda_services/job_service/launcher/utils.py
+++ b/lambda_services/job_service/launcher/utils.py
@@ -1,7 +1,7 @@
 """A collection of utility functions."""
 
 from io import StringIO
-from logging import getLevelName, getLogger, Formatter, INFO, root
+from logging import getLevelName, getLogger, Formatter, INFO
 from re import split
 from os import getenv
 from boto3 import client
@@ -58,8 +58,33 @@ def sanitize_file_name(job_tag, file_name):
     return file_name
 
 
+def _extract_job_tag_from_objectname(s3_object_name: str) -> str:
+    """Parse an S3 object key and return the job tag.
+
+    Args:
+        s3_object_name (str): An S3 object key, prefixed with date and job_id
+
+    Returns:
+        str: the job tag, extracted from the S3 object key
+    """
+    objectname_split: list = s3_object_name.split("/")
+    job_tag: str
+    if len(objectname_split) >= 3:
+        job_tag = f"{objectname_split[-3]}/{objectname_split[-2]}"
+    else:
+        # NOTE: (Eo300) should we raise error here instead?
+        job_tag = s3_object_name
+        _LOGGER.warn(
+            "%s Couldn't extract job tag from object name '%s'. "
+            "Returning object name as job_tag.",
+            job_tag,
+            s3_object_name,
+        )
+    return job_tag
+
+
 def s3_download_file_str(bucket_name: str, object_name: str) -> str:
-    job_tag = f"{bucket_name}/{object_name}"
+    job_tag = _extract_job_tag_from_objectname(object_name)
     try:
         s3_client = client("s3")
         s3_response: dict = s3_client.get_object(
@@ -68,19 +93,28 @@ def s3_download_file_str(bucket_name: str, object_name: str) -> str:
         )
         return s3_response["Body"].read().decode("utf-8")
     except Exception as err:
-        _LOGGER.exception("%s ERROR: %s", job_tag, err)
+        _LOGGER.exception(
+            "%s ERROR downloading '%s' from bucket '%s': %s",
+            job_tag,
+            object_name,
+            bucket_name,
+            err,
+        )
         raise
 
 
 def s3_put_object(bucket_name: str, object_name: str, body):
-    job_tag = f"{bucket_name}/{object_name}"
+    job_tag = _extract_job_tag_from_objectname(object_name)
     s3_client = client("s3")
     _ = s3_client.put_object(
         Bucket=bucket_name,
         Key=object_name,
         Body=body,
     )
-    _LOGGER.info("%s Putting file: %s", job_tag, object_name)
+    # NOTE: (Eo300) Should we log before the put_object() operation?
+    _LOGGER.info(
+        "%s Putting file: %s (bucket: %s)", job_tag, object_name, bucket_name
+    )
 
 
 def s3_object_exists(bucket_name: str, object_name: str) -> bool:
@@ -95,8 +129,9 @@ def s3_object_exists(bucket_name: str, object_name: str) -> bool:
         if err.response["Error"]["Message"] == "NoSuchKey":
             return False
         elif err.response["Error"]["Message"] == "Forbidden":
-            objectname_split: list = object_name.split("/")
-            job_tag: str = f"{objectname_split[-3]}/{objectname_split[-2]}"
+            # objectname_split: list = object_name.split("/")
+            # job_tag: str = f"{objectname_split[-3]}/{objectname_split[-2]}"
+            job_tag: str = _extract_job_tag_from_objectname(object_name)
             _LOGGER.warning(
                 "%s Received '%s' (%d) message on object HEAD: %s",
                 job_tag,


### PR DESCRIPTION
Separated log format override from instantiation of logger used throughout code.  Setting the level in the top-level logger (root_logger) produced unintentional logs from boto3/Lambda environment.

Additionally, I added job tags to some log statements that were missing them or displayed them incorrectly