### PR TITLE
Detect file changes to only build affected files

### DIFF
--- a/build_and_update.sh
+++ b/build_and_update.sh
@@ -21,12 +21,12 @@ build_api_service() {
 build_job_service() {
     echo "Updating Lambda function (Job Service)"
     cd $CODEBUILD_SRC_DIR/lambda_services; zip -r /tmp/job.zip job_service
-    aws lambda update-function-code --function-name apbs-$IMAGE_TAG-job-L --publish --zip-file fileb:///tmp/job.zip    
+    aws lambda update-function-code --function-name apbs-$IMAGE_TAG-job-L --publish --zip-file fileb:///tmp/job.zip
 }
 
 build_docker() {    
     echo "Building the Docker image..."
-    docker build -t $IMAGE_REPO_NAME:main.base src/docker
+    docker build -t $IMAGE_REPO_NAME:main.base $CODEBUILD_SRC_DIR/src/docker
     docker tag $IMAGE_REPO_NAME:main.base    $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
 }
 
@@ -39,10 +39,10 @@ build_changed() {
 
     git diff --name-only $CODEBUILD_RESOLVED_SOURCE_VERSION $LAST_SUCCESSFUL_COMMIT_ID | while read file_path || [[ -n $file_path ]];
     do
-        if [[ $file_path == lambda_services/api_service/* ]] && [[ $api_service_changed -ne 1 ]] # condition to check if path in ./lambda_services/api_service/ directory
+        if [[ $file_path == src/docker/* ]] && [[ $docker_changed -ne 1 ]]
         then
-            api_service_changed=1
-            build_api_service
+            docker_changed=1
+            build_docker
         fi
 
         if [[ $file_path == lambda_services/job_service/* ]] && [[ $job_service_changed -ne 1 ]]
@@ -51,19 +51,19 @@ build_changed() {
             build_job_service
         fi
 
-        if [[ $file_path == src/docker/* ]] && [[ $docker_changed -ne 1 ]]
+        if [[ $file_path == lambda_services/api_service/* ]] && [[ $api_service_changed -ne 1 ]] # condition to check if path in ./lambda_services/api_service/ directory
         then
-            docker_changed=1
-            build_docker
+            api_service_changed=1
+            build_api_service
         fi
     done
 }
 
 build_all() {
     echo "Building all services and containers"
-    build_api_service
-    build_job_service
     build_docker
+    build_job_service
+    build_api_service
 }
 
 cli_argument="$1"

--- a/build_and_update.sh
+++ b/build_and_update.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+show_help() {
+    echo "SYNTAX:   ./build_and_update.sh COMMAND"
+    echo ""
+    echo "COMMANDS:"
+    echo "    all      Builds and updates all services and containers used in deployment."
+    echo ""
+    echo "    changed  Builds and updates services with files modified since the last successful build."
+    echo "             The files changed are determined via git diff of the correstponding commit IDs."
+    echo ""
+    exit 1
+}
+
+build_api_service() {
+    echo "Updating Lambda function (API Service)"
+    cd $CODEBUILD_SRC_DIR/lambda_services; zip -r /tmp/id.zip api_service
+    aws lambda update-function-code --function-name apbs-$IMAGE_TAG-id-L  --publish --zip-file fileb:///tmp/id.zip
+}
+
+build_job_service() {
+    echo "Updating Lambda function (Job Service)"
+    cd $CODEBUILD_SRC_DIR/lambda_services; zip -r /tmp/job.zip job_service
+    aws lambda update-function-code --function-name apbs-$IMAGE_TAG-job-L --publish --zip-file fileb:///tmp/job.zip    
+}
+
+build_docker() {    
+    echo "Building the Docker image..."
+    docker build -t $IMAGE_REPO_NAME:main.base src/docker
+    docker tag $IMAGE_REPO_NAME:main.base    $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
+}
+
+
+build_changed() {
+    echo "Building services and containers modified since last successful build."
+    api_service_changed=0
+    job_service_changed=0
+    docker_changed=0
+
+    git diff --name-only $CODEBUILD_RESOLVED_SOURCE_VERSION $LAST_SUCCESSFUL_COMMIT_ID | while read file_path || [[ -n $file_path ]];
+    do
+        if [[ $file_path == lambda_services/api_service/* ]] && [[ $api_service_changed -ne 1 ]] # condition to check if path in ./lambda_services/api_service/ directory
+        then
+            api_service_changed=1
+            build_api_service
+        fi
+
+        if [[ $file_path == lambda_services/job_service/* ]] && [[ $job_service_changed -ne 1 ]]
+        then
+            job_service_changed=1
+            build_job_service
+        fi
+
+        if [[ $file_path == src/docker/* ]] && [[ $docker_changed -ne 1 ]]
+        then
+            docker_changed=1
+            build_docker
+        fi
+    done
+}
+
+build_all() {
+    echo "Building all services and containers"
+    build_api_service
+    build_job_service
+    build_docker
+}
+
+cli_argument="$1"
+
+if [[ -z $cli_argument ]] ; then
+    echo "No argument provided."
+    show_help
+
+else
+    case $cli_argument in
+        all)
+            build_all
+            ;;
+        changed)
+            build_changed
+            ;;
+        *)
+            show_help
+            ;;
+    esac
+fi

--- a/build_and_update.sh
+++ b/build_and_update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 
 show_help() {
     echo "SYNTAX:   ./build_and_update.sh COMMAND"

--- a/build_and_update.sh
+++ b/build_and_update.sh
@@ -29,8 +29,10 @@ build_docker() {
     docker build -t $IMAGE_REPO_NAME:main.base $CODEBUILD_SRC_DIR/src/docker
     docker tag $IMAGE_REPO_NAME:main.base    $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
 
-    echo Pushing the Docker image...
+    echo "Pushing the Docker image..."
     docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
+
+    #TODO: Restart running ECS task
 }
 
 
@@ -80,11 +82,11 @@ else
         all)
             build_all
             ;;
-        changed)
+        Webhook)
             build_changed
             ;;
         *)
-            show_help
+            build_all
             ;;
     esac
 fi

--- a/build_and_update.sh
+++ b/build_and_update.sh
@@ -28,6 +28,9 @@ build_docker() {
     echo "Building the Docker image..."
     docker build -t $IMAGE_REPO_NAME:main.base $CODEBUILD_SRC_DIR/src/docker
     docker tag $IMAGE_REPO_NAME:main.base    $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
+
+    echo Pushing the Docker image...
+    docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
 }
 
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,5 +1,7 @@
 version: 0.2
 
+env:
+  git-credential-helper: yes  
 phases:
   pre_build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,6 +9,7 @@ phases:
     commands:
       - echo Build started on `date`
       - IMAGE_TAG=test
+      - printenv
       - branch=`echo $CODEBUILD_INITIATOR | awk -F'-' '{ print $NF }'`
       - if [ -n "$branch" ]; then IMAGE_TAG=$branch; fi
       - ls -lR

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,7 +6,7 @@ phases:
       - echo Logging in to Amazon ECR...
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
       - ID=$(aws codepipeline get-pipeline-state --region $AWS_DEFAULT_REGION --name $PIPELINE_NAME --query 'stageStates[?actionStates[?latestExecution.externalExecutionId==`'${CODEBUILD_BUILD_ID}'`]].latestExecution.pipelineExecutionId' --output text)
-      - TRIGGER= $(aws codepipeline list-pipeline-executions --pipeline $PIPELINE_NAME | jq -r ".pipelineExecutionSummaries[]|select(.pipelineExecutionId==\"$ID\")|.trigger.triggerType")
+      - TRIGGER=$(aws codepipeline list-pipeline-executions --pipeline $PIPELINE_NAME | jq -r ".pipelineExecutionSummaries[]|select(.pipelineExecutionId==\"$ID\")|.trigger.triggerType")
       - echo Trigger is $TRIGGER, not WEBHOOK means build all 
   build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,6 +5,9 @@ phases:
     commands:
       - echo Logging in to Amazon ECR...
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+      - ID=$(aws codepipeline get-pipeline-state --region $AWS_DEFAULT_REGION --name $PIPELINE_NAME --query 'stageStates[?actionStates[?latestExecution.externalExecutionId==`'${CODEBUILD_BUILD_ID}'`]].latestExecution.pipelineExecutionId' --output text)
+      - TRIGGER= $(aws codepipeline list-pipeline-executions --pipeline $PIPELINE_NAME | jq -r ".pipelineExecutionSummaries[]|select(.pipelineExecutionId==\"$ID\")|.trigger.triggerType")
+      - echo Trigger is $TRIGGER, not WEBHOOK means build all 
   build:
     commands:
       - echo Build started on `date`

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,8 +5,9 @@ phases:
     commands:
       - echo Logging in to Amazon ECR...
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-      - ID=$(aws codepipeline get-pipeline-state --region $AWS_DEFAULT_REGION --name $PIPELINE_NAME --query 'stageStates[?actionStates[?latestExecution.externalExecutionId==`'${CODEBUILD_BUILD_ID}'`]].latestExecution.pipelineExecutionId' --output text)
-      - TRIGGER=$(aws codepipeline list-pipeline-executions --pipeline $PIPELINE_NAME | jq -r ".pipelineExecutionSummaries[]|select(.pipelineExecutionId==\"$ID\")|.trigger.triggerType")
+      - export PIPELINE_NAME=`echo $CODEBUILD_INITIATOR | cut -c15-`
+      - export ID=$(aws codepipeline get-pipeline-state --region $AWS_DEFAULT_REGION --name $PIPELINE_NAME --query 'stageStates[?actionStates[?latestExecution.externalExecutionId==`'${CODEBUILD_BUILD_ID}'`]].latestExecution.pipelineExecutionId' --output text)
+      - export TRIGGER=$(aws codepipeline list-pipeline-executions --pipeline $PIPELINE_NAME | jq -r ".pipelineExecutionSummaries[]|select(.pipelineExecutionId==\"$ID\")|.trigger.triggerType")
       - echo Trigger is $TRIGGER, not Webhook means build all 
   build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,9 +5,10 @@ phases:
     commands:
       - echo Logging in to Amazon ECR...
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-      - export PIPELINE_NAME=`echo $CODEBUILD_INITIATOR | cut -c15-`
+      - export PIPELINE_NAME=`echo $CODEBUILD_INITIATOR | cut -c14-`
       - export ID=$(aws codepipeline get-pipeline-state --region $AWS_DEFAULT_REGION --name $PIPELINE_NAME --query 'stageStates[?actionStates[?latestExecution.externalExecutionId==`'${CODEBUILD_BUILD_ID}'`]].latestExecution.pipelineExecutionId' --output text)
       - export TRIGGER=$(aws codepipeline list-pipeline-executions --pipeline $PIPELINE_NAME | jq -r ".pipelineExecutionSummaries[]|select(.pipelineExecutionId==\"$ID\")|.trigger.triggerType")
+      - export LAST_SUCCESSFUL_COMMIT_ID=$(aws codepipeline list-pipeline-executions --pipeline-name $PIPELINE_NAME | jq -r '[.pipelineExecutionSummaries[] | select(.status == "Succeeded") | .sourceRevisions[0].revisionId][0]')
       - echo Trigger is $TRIGGER, not Webhook means build all 
   build:
     commands:
@@ -16,20 +17,19 @@ phases:
       - printenv
       - branch=`echo $CODEBUILD_INITIATOR | awk -F'-' '{ print $NF }'`
       - if [ -n "$branch" ]; then IMAGE_TAG=$branch; fi
+      - export IMAGE_TAG
       - ls -lR
-      - lasttime=$(aws ecr describe-images --region $AWS_DEFAULT_REGION --repository-name $IMAGE_REPO_NAME --image-ids imageTag=$IMAGE_TAG | jq -r '.imageDetails[0].imagePushedAt')
-      - dockerchange=$(find src/docker -newermt '@'$lasttime | wc -l)
-      - echo lasttime $lasttime $dockerchange
-      - if [ "$dockerchange" ]; then echo Building the Docker image... $dockerchange ; fi
-      - docker build -t $IMAGE_REPO_NAME:main.base src/docker
-      - docker tag $IMAGE_REPO_NAME:main.base    $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
-      - cd $CODEBUILD_SRC_DIR/lambda_services; zip -r /tmp/job.zip job_service
-      - cd $CODEBUILD_SRC_DIR/lambda_services; zip -r /tmp/id.zip api_service
-      - aws lambda update-function-code --function-name apbs-$IMAGE_TAG-job-L --publish --zip-file fileb:///tmp/job.zip
-      - aws lambda update-function-code --function-name apbs-$IMAGE_TAG-id-L  --publish --zip-file fileb:///tmp/id.zip
-      - echo "CODEBUILD_BATCH_BUILD_IDENTIFIER = $CODEBUILD_BATCH_BUILD_IDENTIFIER"
-      - echo "CODEBUILD_BUILD_ID = $CODEBUILD_BUILD_ID"
-      - echo "CODEBUILD_BUILD_IMAGE = $CODEBUILD_BUILD_IMAGE"
+      # - lasttime=$(aws ecr describe-images --region $AWS_DEFAULT_REGION --repository-name $IMAGE_REPO_NAME --image-ids imageTag=$IMAGE_TAG | jq -r '.imageDetails[0].imagePushedAt')
+      # - dockerchange=$(find src/docker -newermt '@'$lasttime | wc -l)
+      # - echo lasttime $lasttime $dockerchange
+      # - if [ "$dockerchange" ]; then echo Building the Docker image... $dockerchange ; fi
+      # - docker build -t $IMAGE_REPO_NAME:main.base src/docker
+      # - docker tag $IMAGE_REPO_NAME:main.base    $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
+      # - cd $CODEBUILD_SRC_DIR/lambda_services; zip -r /tmp/job.zip job_service
+      # - cd $CODEBUILD_SRC_DIR/lambda_services; zip -r /tmp/id.zip api_service
+      # - aws lambda update-function-code --function-name apbs-$IMAGE_TAG-job-L --publish --zip-file fileb:///tmp/job.zip
+      # - aws lambda update-function-code --function-name apbs-$IMAGE_TAG-id-L  --publish --zip-file fileb:///tmp/id.zip
+      - ./build_and_deploy.sh all # TODO: add conditional to use TRIGGER to determine command to use ('all' or 'changed')
   post_build:
     commands:
       - echo Build completed on `date`

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,7 +7,7 @@ phases:
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
       - ID=$(aws codepipeline get-pipeline-state --region $AWS_DEFAULT_REGION --name $PIPELINE_NAME --query 'stageStates[?actionStates[?latestExecution.externalExecutionId==`'${CODEBUILD_BUILD_ID}'`]].latestExecution.pipelineExecutionId' --output text)
       - TRIGGER=$(aws codepipeline list-pipeline-executions --pipeline $PIPELINE_NAME | jq -r ".pipelineExecutionSummaries[]|select(.pipelineExecutionId==\"$ID\")|.trigger.triggerType")
-      - echo Trigger is $TRIGGER, not WEBHOOK means build all 
+      - echo Trigger is $TRIGGER, not Webhook means build all 
   build:
     commands:
       - echo Build started on `date`

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -18,7 +18,7 @@ phases:
       - branch=`echo $CODEBUILD_INITIATOR | awk -F'-' '{ print $NF }'`
       - if [ -n "$branch" ]; then IMAGE_TAG=$branch; fi
       - export IMAGE_TAG
-      - ls -lR
+      - ls -lRa
       # - lasttime=$(aws ecr describe-images --region $AWS_DEFAULT_REGION --repository-name $IMAGE_REPO_NAME --image-ids imageTag=$IMAGE_TAG | jq -r '.imageDetails[0].imagePushedAt')
       # - dockerchange=$(find src/docker -newermt '@'$lasttime | wc -l)
       # - echo lasttime $lasttime $dockerchange
@@ -29,7 +29,8 @@ phases:
       # - cd $CODEBUILD_SRC_DIR/lambda_services; zip -r /tmp/id.zip api_service
       # - aws lambda update-function-code --function-name apbs-$IMAGE_TAG-job-L --publish --zip-file fileb:///tmp/job.zip
       # - aws lambda update-function-code --function-name apbs-$IMAGE_TAG-id-L  --publish --zip-file fileb:///tmp/id.zip
-      - bash build_and_update.sh changed # TODO: add conditional to use TRIGGER to determine command to use ('all' or 'changed')
+      - git log --pretty=format:"%h %s" | head -20
+      - bash build_and_update.sh changed
   post_build:
     commands:
       - echo Build completed on `date`

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,6 +9,9 @@ phases:
     commands:
       - echo Build started on `date`
       - IMAGE_TAG=test
+      - echo "CODEBUILD_BATCH_BUILD_IDENTIFIER = $CODEBUILD_BATCH_BUILD_IDENTIFIER"
+      - echo "CODEBUILD_BUILD_ID = $CODEBUILD_BUILD_ID"
+      - echo "CODEBUILD_BUILD_IMAGE = $CODEBUILD_BUILD_IMAGE"
       - branch=`echo $CODEBUILD_INITIATOR | awk -F'-' '{ print $NF }'`
       - if [ -n "$branch" ]; then IMAGE_TAG=$branch; fi
       - ls -lR

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -29,9 +29,7 @@ phases:
       # - cd $CODEBUILD_SRC_DIR/lambda_services; zip -r /tmp/id.zip api_service
       # - aws lambda update-function-code --function-name apbs-$IMAGE_TAG-job-L --publish --zip-file fileb:///tmp/job.zip
       # - aws lambda update-function-code --function-name apbs-$IMAGE_TAG-id-L  --publish --zip-file fileb:///tmp/id.zip
-      - ls -l /bin/b*
-      - ls -l /usr/bin/b*
-      - bash build_and_update.sh all # TODO: add conditional to use TRIGGER to determine command to use ('all' or 'changed')
+      - bash build_and_update.sh changed # TODO: add conditional to use TRIGGER to determine command to use ('all' or 'changed')
   post_build:
     commands:
       - echo Build completed on `date`

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -16,23 +16,10 @@ phases:
     commands:
       - echo Build started on `date`
       - IMAGE_TAG=test
-      - printenv
       - branch=`echo $CODEBUILD_INITIATOR | awk -F'-' '{ print $NF }'`
       - if [ -n "$branch" ]; then IMAGE_TAG=$branch; fi
       - export IMAGE_TAG
-      - ls -lRa
-      # - lasttime=$(aws ecr describe-images --region $AWS_DEFAULT_REGION --repository-name $IMAGE_REPO_NAME --image-ids imageTag=$IMAGE_TAG | jq -r '.imageDetails[0].imagePushedAt')
-      # - dockerchange=$(find src/docker -newermt '@'$lasttime | wc -l)
-      # - echo lasttime $lasttime $dockerchange
-      # - if [ "$dockerchange" ]; then echo Building the Docker image... $dockerchange ; fi
-      # - docker build -t $IMAGE_REPO_NAME:main.base src/docker
-      # - docker tag $IMAGE_REPO_NAME:main.base    $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
-      # - cd $CODEBUILD_SRC_DIR/lambda_services; zip -r /tmp/job.zip job_service
-      # - cd $CODEBUILD_SRC_DIR/lambda_services; zip -r /tmp/id.zip api_service
-      # - aws lambda update-function-code --function-name apbs-$IMAGE_TAG-job-L --publish --zip-file fileb:///tmp/job.zip
-      # - aws lambda update-function-code --function-name apbs-$IMAGE_TAG-id-L  --publish --zip-file fileb:///tmp/id.zip
-      - git log --pretty=format:"%h %s" | head -20
-      - bash build_and_update.sh changed
+      - bash build_and_update.sh $TRIGGER
   post_build:
     commands:
       - echo Build completed on `date`

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,9 +9,6 @@ phases:
     commands:
       - echo Build started on `date`
       - IMAGE_TAG=test
-      - echo "CODEBUILD_BATCH_BUILD_IDENTIFIER = $CODEBUILD_BATCH_BUILD_IDENTIFIER"
-      - echo "CODEBUILD_BUILD_ID = $CODEBUILD_BUILD_ID"
-      - echo "CODEBUILD_BUILD_IMAGE = $CODEBUILD_BUILD_IMAGE"
       - branch=`echo $CODEBUILD_INITIATOR | awk -F'-' '{ print $NF }'`
       - if [ -n "$branch" ]; then IMAGE_TAG=$branch; fi
       - ls -lR
@@ -25,6 +22,9 @@ phases:
       - cd $CODEBUILD_SRC_DIR/lambda_services; zip -r /tmp/id.zip api_service
       - aws lambda update-function-code --function-name apbs-$IMAGE_TAG-job-L --publish --zip-file fileb:///tmp/job.zip
       - aws lambda update-function-code --function-name apbs-$IMAGE_TAG-id-L  --publish --zip-file fileb:///tmp/id.zip
+      - echo "CODEBUILD_BATCH_BUILD_IDENTIFIER = $CODEBUILD_BATCH_BUILD_IDENTIFIER"
+      - echo "CODEBUILD_BUILD_ID = $CODEBUILD_BUILD_ID"
+      - echo "CODEBUILD_BUILD_IMAGE = $CODEBUILD_BUILD_IMAGE"
   post_build:
     commands:
       - echo Build completed on `date`

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -29,7 +29,9 @@ phases:
       # - cd $CODEBUILD_SRC_DIR/lambda_services; zip -r /tmp/id.zip api_service
       # - aws lambda update-function-code --function-name apbs-$IMAGE_TAG-job-L --publish --zip-file fileb:///tmp/job.zip
       # - aws lambda update-function-code --function-name apbs-$IMAGE_TAG-id-L  --publish --zip-file fileb:///tmp/id.zip
-      - ./build_and_update.sh all # TODO: add conditional to use TRIGGER to determine command to use ('all' or 'changed')
+      - ls -l /bin/b*
+      - ls -l /usr/bin/b*
+      - bash build_and_update.sh all # TODO: add conditional to use TRIGGER to determine command to use ('all' or 'changed')
   post_build:
     commands:
       - echo Build completed on `date`

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,8 +11,10 @@ phases:
       - IMAGE_TAG=test
       - branch=`echo $CODEBUILD_INITIATOR | awk -F'-' '{ print $NF }'`
       - if [ -n "$branch" ]; then IMAGE_TAG=$branch; fi
+      - ls -lR
       - lasttime=$(aws ecr describe-images --region $AWS_DEFAULT_REGION --repository-name $IMAGE_REPO_NAME --image-ids imageTag=$IMAGE_TAG | jq -r '.imageDetails[0].imagePushedAt')
       - dockerchange=$(find src/docker -newermt '@'$lasttime | wc -l)
+      - echo lasttime $lasttime $dockerchange
       - if [ "$dockerchange" ]; then echo Building the Docker image... $dockerchange ; fi
       - docker build -t $IMAGE_REPO_NAME:main.base src/docker
       - docker tag $IMAGE_REPO_NAME:main.base    $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -33,5 +33,3 @@ phases:
   post_build:
     commands:
       - echo Build completed on `date`
-      - echo Pushing the Docker image...
-      - docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -29,7 +29,7 @@ phases:
       # - cd $CODEBUILD_SRC_DIR/lambda_services; zip -r /tmp/id.zip api_service
       # - aws lambda update-function-code --function-name apbs-$IMAGE_TAG-job-L --publish --zip-file fileb:///tmp/job.zip
       # - aws lambda update-function-code --function-name apbs-$IMAGE_TAG-id-L  --publish --zip-file fileb:///tmp/id.zip
-      - ./build_and_deploy.sh all # TODO: add conditional to use TRIGGER to determine command to use ('all' or 'changed')
+      - ./build_and_update.sh all # TODO: add conditional to use TRIGGER to determine command to use ('all' or 'changed')
   post_build:
     commands:
       - echo Build completed on `date`

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,7 +1,7 @@
 version: 0.2
 
-env:
-  git-credential-helper: yes  
+# env:
+#   git-credential-helper: yes  
 phases:
   pre_build:
     commands:

--- a/lambda_services/job_service/job_service.py
+++ b/lambda_services/job_service/job_service.py
@@ -14,8 +14,6 @@ SQS_QUEUE_NAME = getenv("JOB_QUEUE_NAME")
 JOB_QUEUE_REGION = getenv("JOB_QUEUE_REGION", "us-west-2")
 JOB_MAX_RUNTIME = int(getenv("JOB_MAX_RUNTIME", 2000))
 
-# Initialize logger
-
 
 def get_job_info(
     job_tag: str, bucket_name: str, info_object_name: str

--- a/lambda_services/job_service/launcher/apbs_runner.py
+++ b/lambda_services/job_service/launcher/apbs_runner.py
@@ -27,6 +27,7 @@ class Runner(JobSetup):
         if "filename" in form:
             self.infile_name = form["filename"]
             self.infile_support_filenames = form["support_files"]
+
         elif form is not None:
 
             if "output_scalar" in form:


### PR DESCRIPTION
Addresses #116 by updating `buildspec.yml` to do the following:
* Only build services/containers if there were changed since last successful build
* Build all services/containers if deployed manually

Worth noting that there was a task in #116 to kill running tasks once Docker container pushes. This PR doesn't include this functionality