### PR TITLE
Hotfix to remove libreadline7 package from Dockerfile

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND="noninteractive"
 WORKDIR /app
 RUN apt update -y \
     # Install necessary packages via apt-get
-    && apt install -y wget zip libreadline7 libgomp1 dumb-init python3 python3-boto3 python3-pip \
+    && apt install -y wget zip libgomp1 dumb-init python3 python3-boto3 python3-pip \
     # Install pdb2pqr3 via pip
     && pip3 install pdb2pqr==${PDB2PQR_VERSION} \
     # Download APBS binary from GitHub release


### PR DESCRIPTION
Base Ubuntu image was upgraded and no longer needs/has access to the `libreadline7` package via `apt install`. This patch removes the package from the respective Dockerfile