### PR TITLE
Update PDB2PQR version to v3.6.1

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
     "aws": "REPLACE ME",
     "apbs": "3.4.1",
-    "pdb2pqr": "3.6.0"
+    "pdb2pqr": "3.6.1"
 }

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
     "aws": "REPLACE ME",
     "apbs": "3.4.1",
-    "pdb2pqr": "3.5.2"
+    "pdb2pqr": "3.6.0"
 }


### PR DESCRIPTION
Resolves #176 

~~**NOTE**: Leaving PR in Draft mode until the new PDB2PQR [version v3.6.0](https://github.com/Electrostatics/pdb2pqr/releases/tag/v3.6.0) is available via [PyPI](https://pypi.org/project/pdb2pqr/). Testing this change in dev server currently pulls v3.5.2~~

**UPDATE**: Version v3.6.1 has been released and is [available via PyPI](https://pypi.org/project/pdb2pqr/3.6.1/). This branch has been updated accordingly